### PR TITLE
Don't reset file map

### DIFF
--- a/BlazorInputFile/wwwroot/inputfile.js
+++ b/BlazorInputFile/wwwroot/inputfile.js
@@ -2,10 +2,10 @@
     window.BlazorInputFile = {
         init: function init(elem, componentInstance) {
             elem._blazorInputFileNextFileId = 0;
+            elem._blazorFilesById = {};
 
             elem.addEventListener('change', function handleInputFileChange(event) {
-                // Reduce to purely serializable data, plus build an index by ID
-                elem._blazorFilesById = {};
+                // Reduce to purely serializable data, plus build an index by ID                
                 var fileList = Array.prototype.map.call(elem.files, function (file) {
                     var result = {
                         id: ++elem._blazorInputFileNextFileId,


### PR DESCRIPTION
Currently the `elem._blazorFilesById` field with the file map reset every time the `change` event is triggered (e.g. when a new file is selected). This causes issues when selecting multiple files and uploading them at once since the file cannot be found in the map anymore.

Fixes #36